### PR TITLE
Closes #4 keep independent rng

### DIFF
--- a/benches/bench_energy.rs
+++ b/benches/bench_energy.rs
@@ -1,14 +1,16 @@
 #![feature(test)]
 extern crate vegas_rs;
 extern crate test;
+extern crate rand;
 
 use vegas_rs::state::{Spin, HeisenbergSpin, State};
 use vegas_rs::energy::{Gauge, UniaxialAnisotropy, EnergyComponent, CompoundEnergy};
+use rand::thread_rng;
 
 
 #[bench]
 fn gauge_energy_of_a_1_k_heisenberg_state(b: &mut test::Bencher) {
-    let state = State::<HeisenbergSpin>::rand_with_size(1_000);
+    let state = State::<HeisenbergSpin>::rand_with_size(1_000, &mut thread_rng());
     let gauge = Gauge::new(1.0);
     b.iter(|| {
         let energy = gauge.total_energy(&state);

--- a/benches/bench_integration.rs
+++ b/benches/bench_integration.rs
@@ -5,14 +5,14 @@ extern crate test;
 
 use vegas_rs::state::{Spin, IsingSpin, HeisenbergSpin, State};
 use vegas_rs::energy::{Gauge, UniaxialAnisotropy};
-use vegas_rs::integrator::{Integrator, MetropolisIntegrator};
+use vegas_rs::integrator::{Integrator, StateGenerator, MetropolisIntegrator};
 
 
 #[bench]
 fn integration_of_1k_heisenberg_spin_with_gauge(b: &mut test::Bencher) {
     let gauge = Gauge::new(1.0);
     let mut integrator = MetropolisIntegrator::new(3.0);
-    let mut state = State::<HeisenbergSpin>::rand_with_size(1_000);
+    let mut state: State<HeisenbergSpin> = integrator.state(1_000);
     b.iter(|| {
         state = integrator.step(&gauge, &state)
     })
@@ -23,7 +23,7 @@ fn integration_of_1k_heisenberg_spin_with_gauge(b: &mut test::Bencher) {
 fn integration_of_1k_ising_spin_with_gauge(b: &mut test::Bencher) {
     let gauge = Gauge::new(1.0);
     let mut integrator = MetropolisIntegrator::new(3.0);
-    let mut state = State::<IsingSpin>::rand_with_size(1_000);
+    let mut state: State<IsingSpin> = integrator.state(1_000);
     b.iter(|| {
         state = integrator.step(&gauge, &state)
     })
@@ -37,7 +37,7 @@ fn integration_of_1k_heisenberg_spin_with_compound_energy(b: &mut test::Bencher)
         UniaxialAnisotropy::new(HeisenbergSpin::up(), 10.0)
     );
     let mut integrator = MetropolisIntegrator::new(3.0);
-    let mut state = State::<HeisenbergSpin>::rand_with_size(1_000);
+    let mut state: State<HeisenbergSpin> = integrator.state(1_000);
     b.iter(|| {
         state = integrator.step(&hamiltonian, &state)
     })

--- a/benches/bench_integration.rs
+++ b/benches/bench_integration.rs
@@ -11,7 +11,7 @@ use vegas_rs::integrator::{Integrator, MetropolisIntegrator};
 #[bench]
 fn integration_of_1k_heisenberg_spin_with_gauge(b: &mut test::Bencher) {
     let gauge = Gauge::new(1.0);
-    let integrator = MetropolisIntegrator::new(3.0);
+    let mut integrator = MetropolisIntegrator::new(3.0);
     let mut state = State::<HeisenbergSpin>::rand_with_size(1_000);
     b.iter(|| {
         state = integrator.step(&gauge, &state)
@@ -22,7 +22,7 @@ fn integration_of_1k_heisenberg_spin_with_gauge(b: &mut test::Bencher) {
 #[bench]
 fn integration_of_1k_ising_spin_with_gauge(b: &mut test::Bencher) {
     let gauge = Gauge::new(1.0);
-    let integrator = MetropolisIntegrator::new(3.0);
+    let mut integrator = MetropolisIntegrator::new(3.0);
     let mut state = State::<IsingSpin>::rand_with_size(1_000);
     b.iter(|| {
         state = integrator.step(&gauge, &state)
@@ -36,7 +36,7 @@ fn integration_of_1k_heisenberg_spin_with_compound_energy(b: &mut test::Bencher)
         Gauge::new(1.0),
         UniaxialAnisotropy::new(HeisenbergSpin::up(), 10.0)
     );
-    let integrator = MetropolisIntegrator::new(3.0);
+    let mut integrator = MetropolisIntegrator::new(3.0);
     let mut state = State::<HeisenbergSpin>::rand_with_size(1_000);
     b.iter(|| {
         state = integrator.step(&hamiltonian, &state)

--- a/benches/bench_spin.rs
+++ b/benches/bench_spin.rs
@@ -1,31 +1,36 @@
 #![feature(test)]
 extern crate vegas_rs;
 extern crate test;
+extern crate rand;
 
 use vegas_rs::state::{Spin, IsingSpin, HeisenbergSpin, State};
+use rand::XorShiftRng;
 
 
 #[bench]
 fn create_1k_ising_spins(b: &mut test::Bencher) {
+    let mut rng = XorShiftRng::new_unseeded();
     b.iter(|| {
         for _ in 0..1_000 {
-            let _spin = IsingSpin::rand();
+            let _spin = IsingSpin::rand(&mut rng);
         }
     });
 }
 
 #[bench]
 fn create_1k_heisenberg_spins(b: &mut test::Bencher) {
+    let mut rng = XorShiftRng::new_unseeded();
     b.iter(|| {
         for _ in 0..1_000 {
-            let _spin = HeisenbergSpin::rand();
+            let _spin = HeisenbergSpin::rand(&mut rng);
         }
     });
 }
 
 #[bench]
 fn create_a_1k_spin_state(b: &mut test::Bencher) {
+    let mut rng = XorShiftRng::new_unseeded();
     b.iter(|| {
-        let _state = State::<HeisenbergSpin>::rand_with_size(1_000);
+        let _state = State::<HeisenbergSpin>::rand_with_size(1_000, &mut rng);
     })
 }

--- a/src/integrator.rs
+++ b/src/integrator.rs
@@ -1,23 +1,29 @@
 extern crate rand;
+
 use rand::distributions::{IndependentSample, Range};
+use rand::{Rng, XorShiftRng};
 
 use state::{Spin, State};
 use energy::EnergyComponent;
 
 
 pub trait Integrator<S: Spin, T: EnergyComponent<S>> {
-    fn step(&self, energy: &T, state: &State<S>) -> State<S>;
+    fn step(&mut self, energy: &T, state: &State<S>) -> State<S>;
 }
 
 
 pub struct MetropolisIntegrator {
+    rng: XorShiftRng,
     temp: f64,
 }
 
 
 impl MetropolisIntegrator {
     pub fn new(temp: f64) -> MetropolisIntegrator {
-        MetropolisIntegrator { temp: temp }
+        MetropolisIntegrator {
+            temp: temp,
+            rng: XorShiftRng::new_unseeded(),
+        }
     }
 
     pub fn temp(&self) -> f64 {
@@ -38,12 +44,11 @@ impl<S, T> Integrator<S, T> for MetropolisIntegrator where
     S: Spin + Clone,
     T: EnergyComponent<S>
 {
-    fn step(&self, energy: &T, state: &State<S>) -> State<S> {
+    fn step(&mut self, energy: &T, state: &State<S>) -> State<S> {
         let mut new_state = (*state).clone();
         let sites = Range::new(0, new_state.len());
-        let mut rng = rand::thread_rng();
         for _ in 0..new_state.len() {
-            let site = sites.ind_sample(&mut rng);
+            let site = sites.ind_sample(&mut self.rng);
             let old_energy = energy.energy(&new_state, site);
             new_state.set_at(site, Spin::rand());
             let new_energy = energy.energy(&new_state, site);
@@ -51,7 +56,7 @@ impl<S, T> Integrator<S, T> for MetropolisIntegrator where
             if delta < 0.0 {
                 continue
             }
-            if rand::random::<f64>() < (- delta / self.temp).exp() {
+            if self.rng.gen::<f64>() < (- delta / self.temp).exp() {
                 continue
             }
             new_state.set_at(site, state.at(site).clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,18 +2,18 @@
 
 use vegas_rs::state::{State, HeisenbergSpin};
 use vegas_rs::energy::{EnergyComponent, Gauge};
-use vegas_rs::integrator::{Integrator, MetropolisIntegrator};
+use vegas_rs::integrator::{Integrator, StateGenerator, MetropolisIntegrator};
 
 
 pub fn main() {
 
-    let mut state: State<HeisenbergSpin> = State::rand_with_size(100);
 
     let hamiltonian = hamiltonian!(
         Gauge::new(10.0)
     );
 
     let mut integrator = MetropolisIntegrator::new(3.0);
+    let mut state: State<HeisenbergSpin> = integrator.state(100);
 
     loop {
         let steps = 1000;


### PR DESCRIPTION
Keeping the `rng` as a reference instead of creating a thread local rng every time looks like a good way to imporve performance, the metropolis integrator will take a `XorShift` rng for now since it's quite reputable.