### PR TITLE
implement the Wolff algorithm for the Ising spin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ data*
 Cargo.lock
 .idea
 *.parquet
+*.out

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vegas"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Oscar Arbelaez <oscar@arbelaez.dev>"]
 description = "Little Monte Carlo code in rust"
 keywords = ["Monte-Carlo", "MCMC", "physics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 
 [dependencies]
 rand = { version = "0.9", features = ["small_rng"] }
-vegas-lattice = "0.11"
+vegas-lattice = "0.11.1"
 sprs = "0.11"
 clap = { version = "4.5", features = ["cargo", "derive"] }
 rand_pcg = "0.9"

--- a/README.md
+++ b/README.md
@@ -91,8 +91,17 @@ frequency = 1000
 You can run the simulation by executing the following command:
 
 ```bash
-vegas run input.toml
+vegas metropolis input.toml
 ```
+
+There's a simmilar input for the Wolff algorithm, you can run with the following
+command:
+
+
+```bash
+vegas wolff input.toml
+```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can run the simulation by executing the following command:
 vegas run metropolis input.toml
 ```
 
-There's a simmilar input for the Wolff algorithm, you can run with the following
+There's a similar input for the Wolff algorithm, you can run with the following
 command:
 
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ frequency = 1000
 You can run the simulation by executing the following command:
 
 ```bash
-vegas metropolis input.toml
+vegas run metropolis input.toml
 ```
 
 There's a simmilar input for the Wolff algorithm, you can run with the following
@@ -99,7 +99,7 @@ command:
 
 
 ```bash
-vegas wolff input.toml
+vegas run wolff input.toml
 ```
 
 

--- a/docs/metropolis.toml
+++ b/docs/metropolis.toml
@@ -16,12 +16,12 @@ z = true
 [[steps]]
 program = "Relax"
 steps = 1000
-temperature = 5.0
+temperature = 6.0
 
 [[steps]]
 program = "CoolDown"
-max_temperature = 5.0
-min_temperature = 0.01
+max_temperature = 6.0
+min_temperature = 1.0
 cool_rate = 0.05
 relax = 1000
 steps = 20000

--- a/docs/metropolis.toml
+++ b/docs/metropolis.toml
@@ -1,0 +1,34 @@
+model = "Ising"
+
+[sample.unitcell]
+name = "sc"
+
+[sample.size]
+x = 10
+y = 10
+z = 10
+
+[sample.pbc]
+x = true
+y = true
+z = true
+
+[[steps]]
+program = "Relax"
+steps = 1000
+temperature = 5.0
+
+[[steps]]
+program = "CoolDown"
+max_temperature = 5.0
+min_temperature = 0.01
+cool_rate = 0.05
+relax = 1000
+steps = 20000
+
+[output]
+raw = "./output.parquet"
+
+[output.state]
+path = "./state.parquet"
+frequency = 1000

--- a/docs/wolff.toml
+++ b/docs/wolff.toml
@@ -1,28 +1,26 @@
-model = "Ising"
-
 [sample.unitcell]
 name = "sc"
 
 [sample.size]
 x = 10
 y = 10
-z = 1
+z = 10
 
 [sample.pbc]
 x = true
 y = true
-z = false
+z = true
 
 [[steps]]
 program = "Relax"
 steps = 1000
-temperature = 4.0
+temperature = 5.0
 
 [[steps]]
 program = "CoolDown"
-max_temperature = 4.0
-min_temperature = 0.1
-cool_rate = 0.1
+max_temperature = 5.0
+min_temperature = 0.01
+cool_rate = 0.05
 relax = 1000
 steps = 20000
 

--- a/docs/wolff.toml
+++ b/docs/wolff.toml
@@ -14,12 +14,12 @@ z = true
 [[steps]]
 program = "Relax"
 steps = 1000
-temperature = 5.0
+temperature = 6.0
 
 [[steps]]
 program = "CoolDown"
-max_temperature = 5.0
-min_temperature = 0.01
+max_temperature = 6.0
+min_temperature = 1.0
 cool_rate = 0.05
 relax = 1000
 steps = 20000

--- a/src/input.rs
+++ b/src/input.rs
@@ -156,6 +156,12 @@ pub struct MetropolisInput {
     output: Option<Output>,
 }
 
+impl MetropolisInput {
+    pub fn builder() -> MetropolisInputBuilder {
+        MetropolisInputBuilder::new()
+    }
+}
+
 impl Default for MetropolisInput {
     fn default() -> Self {
         MetropolisInput {
@@ -318,6 +324,12 @@ pub struct WolffInput {
     output: Option<Output>,
 }
 
+impl WolffInput {
+    pub fn builder() -> WolffInputBuilder {
+        WolffInputBuilder::new()
+    }
+}
+
 impl Default for WolffInput {
     fn default() -> Self {
         WolffInput {
@@ -441,7 +453,7 @@ impl WolffInput {
 
     pub fn run<R: Rng>(&self, rng: &mut R) -> VegasResult<()> {
         let lattice = self.lattice();
-        let integrator = WolffIntegrator::from_lattice(&lattice);
+        let integrator = WolffIntegrator::from_lattice(self.exchange.unwrap_or(1.0), &lattice);
         let hamiltonian = hamiltonian!(Exchange::from_lattice(&lattice));
         let instruments = self.instruments()?;
         let mut machine = Machine::new(

--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -258,7 +258,7 @@ where
     step: usize,
     stage: usize,
     thermostat: Option<Thermostat<S>>,
-    phantom_h: PhantomData<H>,
+    phantom: PhantomData<H>,
 }
 
 impl<H, S> StateSensor<H, S>
@@ -274,7 +274,7 @@ where
             stage: 0,
             step: 0,
             thermostat: None,
-            phantom_h: PhantomData,
+            phantom: PhantomData,
         })
     }
 }
@@ -328,7 +328,7 @@ where
             && let Some(thermostat) = &self.thermostat
         {
             self.io
-                .write(relax, self.stage, self.step, &thermostat, &state)?;
+                .write(relax, self.stage, self.step, thermostat, state)?;
         }
         self.step += 1;
         Ok(())

--- a/src/integrator.rs
+++ b/src/integrator.rs
@@ -188,19 +188,19 @@ impl Integrator<IsingSpin> for WolffIntegrator {
         let mut queue = VecDeque::new();
         queue.push_back(source);
         let mut visited = vec![false; state.len()];
-        let mut cluster = vec![source];
+        let mut cluster = vec![];
         while let Some(site) = queue.pop_front() {
             if visited[site] {
                 continue;
             }
             visited[site] = true;
+            cluster.push(site);
             let spin = state.at(site);
             for &neighbor in &self.neighbor_list[site] {
                 if !visited[neighbor] && state.at(neighbor) == spin {
                     let prob = 1.0 - (-2.0 / thermostat.temperature()).exp();
                     if rng.random::<f64>() < prob {
                         queue.push_back(neighbor);
-                        cluster.push(neighbor);
                     }
                 }
             }

--- a/src/io.rs
+++ b/src/io.rs
@@ -57,7 +57,7 @@ impl ObservableParquetIO {
         let step: UInt64Array = (0..energy.len()).map(|i| i as u64).collect();
         let stage: UInt64Array = repeat_n(stage as u64, energy.len()).collect();
         let relax: BooleanArray = repeat_n(Some(relax), energy.len()).collect();
-        let temp: Float64Array = repeat_n(thermostat.temperature(), energy.len()).collect();
+        let temperature: Float64Array = repeat_n(thermostat.temperature(), energy.len()).collect();
         let field: Float64Array = repeat_n(thermostat.field().magnitude(), energy.len()).collect();
         let energy: Float64Array = Float64Array::from(energy.to_owned());
         let magnetization: Float64Array = Float64Array::from(magnetization.to_owned());
@@ -68,7 +68,7 @@ impl ObservableParquetIO {
                 Arc::new(relax),
                 Arc::new(stage),
                 Arc::new(step),
-                Arc::new(temp),
+                Arc::new(temperature),
                 Arc::new(field),
                 Arc::new(energy),
                 Arc::new(magnetization),
@@ -106,6 +106,8 @@ impl StateParquetIO {
             Field::new("relax", DataType::Boolean, false),
             Field::new("stage", DataType::UInt64, false),
             Field::new("step", DataType::UInt64, false),
+            Field::new("temperature", DataType::Float64, false),
+            Field::new("field", DataType::Float64, false),
             Field::new("id", DataType::UInt64, false),
             Field::new("sx", DataType::Float64, false),
             Field::new("sy", DataType::Float64, false),
@@ -126,11 +128,14 @@ impl StateParquetIO {
         relax: bool,
         stage: usize,
         step: usize,
+        thermostat: &Thermostat<S>,
         state: &State<S>,
     ) -> IoResult<()> {
         let relax = BooleanArray::from(repeat_n(relax, state.len()).collect::<Vec<_>>());
         let stage = UInt64Array::from(repeat_n(stage as u64, state.len()).collect::<Vec<_>>());
         let step = UInt64Array::from(repeat_n(step as u64, state.len()).collect::<Vec<_>>());
+        let temperature: Float64Array = repeat_n(thermostat.temperature(), state.len()).collect();
+        let field: Float64Array = repeat_n(thermostat.field().magnitude(), state.len()).collect();
         let id = UInt64Array::from((0..state.len()).map(|i| i as u64).collect::<Vec<_>>());
         let sx = Float64Array::from(state.spins().iter().map(|s| s.sx()).collect::<Vec<_>>());
         let sy = Float64Array::from(state.spins().iter().map(|s| s.sy()).collect::<Vec<_>>());
@@ -141,6 +146,8 @@ impl StateParquetIO {
                 Arc::new(relax),
                 Arc::new(stage),
                 Arc::new(step),
+                Arc::new(temperature),
+                Arc::new(field),
                 Arc::new(id),
                 Arc::new(sx),
                 Arc::new(sy),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@
 //!
 //! use vegas::{
 //!     energy::Exchange,
-//!     input::{Input, Model},
 //!     instrument::{Instrument, StatSensor},
 //!     integrator::MetropolisIntegrator,
 //!     machine::Machine,

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ enum SubCommand {
     },
     /// Print the default input
     Input,
-    /// Run a Wolf simulation from an input file
+    /// Run simulations
     Run {
         /// Integrator to run
         integrator: Integrator,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 //! A command line interface for running Vegas simulations and benchmarks.
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use rand::SeedableRng;
 use rand_pcg::Pcg64;
 use std::{
@@ -100,6 +100,14 @@ fn check_error(res: VegasResult<()>) {
     }
 }
 
+#[derive(Debug, Clone, ValueEnum)]
+enum Integrator {
+    /// Metropolis integrator
+    Metropolis,
+    /// Wolff integrator
+    Wolff,
+}
+
 #[derive(Debug, Subcommand)]
 enum SubCommand {
     /// Run benchmarks
@@ -111,10 +119,13 @@ enum SubCommand {
     },
     /// Print the default input
     Input,
-    /// Run a Metropolis simulation from an input file
-    Metropolis { input: PathBuf },
     /// Run a Wolf simulation from an input file
-    Wolff { input: PathBuf },
+    Run {
+        /// Integrator to run
+        integrator: Integrator,
+        /// Input file
+        input: PathBuf,
+    },
 }
 
 #[derive(Debug, Parser)]
@@ -129,7 +140,9 @@ fn main() {
     match cli.subcmd {
         SubCommand::Bench { length, model } => check_error(bench_model(model, length)),
         SubCommand::Input => check_error(print_default_input()),
-        SubCommand::Metropolis { input } => check_error(run_metropolis(input)),
-        SubCommand::Wolff { input } => check_error(run_wolff(input)),
+        SubCommand::Run { integrator, input } => match integrator {
+            Integrator::Metropolis => check_error(run_metropolis(input)),
+            Integrator::Wolff => check_error(run_wolff(input)),
+        },
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -241,7 +241,7 @@ impl<S: Spin> Sum<S> for Field<S> {
 }
 
 /// A state of spins.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct State<S: Spin>(Vec<S>);
 
 impl<S: Spin> State<S> {
@@ -292,6 +292,27 @@ impl<S: Spin> State<S> {
         S: Spin,
     {
         self.spins().iter().cloned().sum()
+    }
+}
+
+impl<S> IntoIterator for State<S>
+where
+    S: Spin,
+{
+    type Item = S;
+    type IntoIter = std::vec::IntoIter<S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<S> FromIterator<S> for State<S>
+where
+    S: Spin,
+{
+    fn from_iter<T: IntoIterator<Item = S>>(iter: T) -> Self {
+        State::<S>(iter.into_iter().collect())
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -190,13 +190,6 @@ impl Spin for HeisenbergSpin {
     }
 }
 
-impl Flip for HeisenbergSpin {
-    fn flip(&self) -> Self {
-        let HeisenbergSpin(a) = self;
-        HeisenbergSpin([-a[0], -a[1], -a[2]])
-    }
-}
-
 /// Field represents a magnetic field for the given spin type.
 #[derive(Debug, Clone)]
 pub struct Field<S: Spin> {
@@ -223,7 +216,7 @@ impl<S: Spin> Field<S> {
 
     /// Get the magnitude of the field.
     pub fn magnitude(&self) -> f64 {
-        self.magnitude
+        self.magnitude.abs()
     }
 
     /// Get the orientation of the field.


### PR DESCRIPTION
This pull request introduces support for the Wolff cluster algorithm alongside the existing Metropolis algorithm, refactors input handling to distinguish between the two simulation types, and enhances output data with additional metadata. It also updates documentation and sample configuration files to reflect these changes.

**New simulation algorithm support:**

* Added a full implementation of the Wolff cluster algorithm via the new `WolffIntegrator` struct and related logic in `src/integrator.rs`, including cluster construction, spin flipping, and integration with the simulation framework.
* Introduced new input structures: `MetropolisInput` and `WolffInput`, each with their own builders and methods, to cleanly separate configuration and execution paths for the two algorithms in `src/input.rs`. [[1]](diffhunk://#diff-b28dbadb7b0fb54a6a72860d79ba4fa2c1228788e81a14dbd99f8536f5e317a9L148-R161) [[2]](diffhunk://#diff-b28dbadb7b0fb54a6a72860d79ba4fa2c1228788e81a14dbd99f8536f5e317a9R311-R469)

**Command-line and input handling:**

* Refactored the CLI to support separate subcommands for running Metropolis and Wolff simulations (`vegas metropolis` and `vegas wolff`), and updated input parsing accordingly in `src/main.rs`.

**Output and instrumentation improvements:**

* Enhanced the state and observable output Parquet files to include temperature and field metadata for each recorded step, requiring changes to IO logic and the `StateSensor` instrument in `src/instrument.rs` and `src/io.rs`. [[1]](diffhunk://#diff-3c11a7b43b2b647fb7a3497aa921e17c94794cdb1d88d7eddac03a57c1eddd0cL289-R331) [[2]](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R109-R110) [[3]](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R131-R138)

**Documentation and configuration updates:**

* Updated the `README.md` to document the new Wolff algorithm and its usage, and added/renamed TOML configuration files for both Metropolis and Wolff simulations in the `docs` directory. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R105) [[2]](diffhunk://#diff-30bdbbb4d1f1b3b275432998e69353b81bd723f96bc8ef746d28cc06c97fc333L9-R25) [[3]](diffhunk://#diff-822f61f56059cc7870ad47738793ef2d66b249119ab547a6069bea2a383a18fdR1-R32)

**Dependency updates:**

* Updated the `vegas-lattice` dependency to version 0.11.1 in `Cargo.toml`.
