### PR TITLE
feat: write partial parquet files to a tmp location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vegas"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Oscar Arbelaez <oscar@arbelaez.dev>"]
 description = "Little Monte Carlo code in rust"
 keywords = ["Monte-Carlo", "MCMC", "physics"]


### PR DESCRIPTION
Since partially written parquet files are invalid, we want to store them
to a temp location. This enables a system like duckdb to make queries
like:

```sql
SELECT *
FROM "files/*/*.parquet
```

Without running into the partially written parquet files.
