### PR TITLE
feat!: update input system to support multiple algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@
 
 ## Introduction
 
-This is an experimental implementation of an atomistic simulation package for
-magnetic systems. **vegas**'s main goal is to determine how performant is the
-[rust](www.rust-lang.com) language for this kind of application.
+**vegas** is a feature rich atomistic magnetic material simulation platform
+written in [rust](https://rust-lang.org/). It supports Ising and Heisenberg
+spins, as well as a couple of Monte Carlo algorithms, namely Metropolis and
+Wolff.
+
+Vegas is meant to be used as a library to build your custom magnetic material
+simulation programs. That said, there's an included program that can handle
+generic input and can be used as a reference implementation for your own
+programs.
 
 ## Installation
 
@@ -47,6 +53,7 @@ file is given below:
 ```toml
 # Model definition can be Ising or Heisenberg
 model = "Ising"
+algorithm = "Metropolis"
 
 # You can create unit cells of different lattice types.
 [sample.unitcell]
@@ -91,17 +98,8 @@ frequency = 1000
 You can run the simulation by executing the following command:
 
 ```bash
-vegas run metropolis input.toml
+vegas run input.toml
 ```
-
-There's a similar input for the Wolff algorithm, you can run with the following
-command:
-
-
-```bash
-vegas run wolff input.toml
-```
-
 
 ## Contributing
 
@@ -109,6 +107,6 @@ Contributions are welcome! Please open an issue or submit a pull request on
 GitHub. There are currently some missing features that would benefit the
 package, such as:
 
-- Custom exchange interaction values (so far we only support `1.0`).
+- Custom exchange interaction values, we currently support only one value.
 - More Hamiltonian terms (Dzyaloshinskii-Moriya, Dipolar, etc).
 - More integration algorithms (Wolff, Swendsen-Wang, etc).

--- a/docs/metropolis.toml
+++ b/docs/metropolis.toml
@@ -1,4 +1,5 @@
 model = "Ising"
+algorithm = "Metropolis"
 
 [sample.unitcell]
 name = "sc"

--- a/docs/wolff.toml
+++ b/docs/wolff.toml
@@ -1,3 +1,6 @@
+model = "Ising"
+algorithm = "Wolff"
+
 [sample.unitcell]
 name = "sc"
 

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -173,13 +173,13 @@ impl Exchange {
     }
 
     /// Create a new exchange energy from a lattice.
-    pub fn from_lattice(lattice: &Lattice) -> Self {
+    pub fn from_lattice(exchange: f64, lattice: &Lattice) -> Self {
         let nsites = lattice.sites().len();
         let mut mat = TriMat::<f64>::new((nsites, nsites));
         for vertex in lattice.vertices() {
             if vertex.source() <= vertex.target() {
-                mat.add_triplet(vertex.source(), vertex.target(), 1.0);
-                mat.add_triplet(vertex.target(), vertex.source(), 1.0);
+                mat.add_triplet(vertex.source(), vertex.target(), exchange);
+                mat.add_triplet(vertex.target(), vertex.source(), exchange);
             }
         }
         let csr = mat.to_csr();

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ pub enum VegasError {
     TomlDeserializeError(#[from] TomlDeserializeError),
     #[error("toml serialization error: {0}")]
     TomlSerializeError(#[from] TomlSerializeError),
-    #[error("not implmented error")]
+    #[error("not implemented error")]
     NotImplementedError,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum VegasError {
     TomlDeserializeError(#[from] TomlDeserializeError),
     #[error("toml serialization error: {0}")]
     TomlSerializeError(#[from] TomlSerializeError),
+    #[error("not implmented error")]
+    NotImplementedError,
 }
 
 /// Error type for program misconfiguration

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     energy::{Exchange, Hamiltonian, ZeemanEnergy},
-    error::VegasResult,
+    error::{VegasError, VegasResult},
     instrument::{Instrument, RawStatSensor, StatSensor, StateSensor},
     integrator::{Integrator, MetropolisFlipIntegrator, MetropolisIntegrator, WolffIntegrator},
     machine::Machine,
@@ -23,6 +23,15 @@ pub enum Model {
     Ising,
     /// Heisenberg model
     Heisenberg,
+}
+
+#[derive(Debug, Default, Clone, ValueEnum, Serialize, Deserialize)]
+pub enum Algorithm {
+    /// Metropolis algorithm
+    #[default]
+    Metropolis,
+    /// Wolff cluster algorithm
+    Wolff,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
@@ -145,9 +154,13 @@ impl Default for Step {
 
 /// Input for a generic simulation.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct MetropolisInput {
+pub struct Input {
     /// Model to simulate
     model: Model,
+    /// Algorithm to use
+    algorithm: Algorithm,
+    /// Exchange interaction
+    exchange: Option<f64>,
     /// Sample to simulate
     sample: Sample,
     /// Steps to take
@@ -156,16 +169,18 @@ pub struct MetropolisInput {
     output: Option<Output>,
 }
 
-impl MetropolisInput {
-    pub fn builder() -> MetropolisInputBuilder {
-        MetropolisInputBuilder::new()
+impl Input {
+    pub fn builder() -> InputBuilder {
+        InputBuilder::new()
     }
 }
 
-impl Default for MetropolisInput {
+impl Default for Input {
     fn default() -> Self {
-        MetropolisInput {
+        Input {
             model: Default::default(),
+            algorithm: Default::default(),
+            exchange: Default::default(),
             sample: Default::default(),
             steps: vec![
                 Step::Relax(Relax::default()),
@@ -176,17 +191,21 @@ impl Default for MetropolisInput {
     }
 }
 
-pub struct MetropolisInputBuilder {
+pub struct InputBuilder {
     model: Option<Model>,
+    algorithm: Option<Algorithm>,
+    exchange: Option<f64>,
     sample: Option<Sample>,
     steps: Option<Vec<Step>>,
     output: Option<Output>,
 }
 
-impl MetropolisInputBuilder {
+impl InputBuilder {
     pub fn new() -> Self {
-        MetropolisInputBuilder {
+        InputBuilder {
             model: None,
+            algorithm: None,
+            exchange: None,
             sample: None,
             steps: None,
             output: None,
@@ -195,6 +214,16 @@ impl MetropolisInputBuilder {
 
     pub fn model(mut self, model: Model) -> Self {
         self.model = Some(model);
+        self
+    }
+
+    pub fn algorithm(mut self, algorithm: Algorithm) -> Self {
+        self.algorithm = Some(algorithm);
+        self
+    }
+
+    pub fn exchange(mut self, exchange: f64) -> Self {
+        self.exchange = Some(exchange);
         self
     }
 
@@ -213,9 +242,11 @@ impl MetropolisInputBuilder {
         self
     }
 
-    pub fn build(self) -> MetropolisInput {
-        MetropolisInput {
+    pub fn build(self) -> Input {
+        Input {
             model: self.model.unwrap_or_default(),
+            algorithm: self.algorithm.unwrap_or_default(),
+            exchange: self.exchange,
             sample: self.sample.unwrap_or_default(),
             steps: self.steps.unwrap_or_default(),
             output: self.output,
@@ -223,20 +254,24 @@ impl MetropolisInputBuilder {
     }
 }
 
-impl Default for MetropolisInputBuilder {
+impl Default for InputBuilder {
     fn default() -> Self {
-        MetropolisInputBuilder::new()
+        InputBuilder::new()
     }
 }
 
-impl MetropolisInput {
+impl Input {
     fn run_with_spin<S: Spin + 'static, R: Rng, I: Integrator<S>>(
         &self,
         rng: &mut R,
         integrator: I,
+        exchange: f64,
     ) -> VegasResult<()> {
         let lattice = self.lattice();
-        let hamiltonian = hamiltonian!(Exchange::from_lattice(&lattice), ZeemanEnergy::new());
+        let hamiltonian = hamiltonian!(
+            Exchange::from_lattice(exchange, &lattice),
+            ZeemanEnergy::new()
+        );
         let instruments = self.instruments::<_, S>()?;
         let mut machine = Machine::new(
             Thermostat::new(2.8, Field::zero()),
@@ -311,178 +346,24 @@ impl MetropolisInput {
     }
 
     pub fn run<R: Rng>(&self, rng: &mut R) -> VegasResult<()> {
-        match self.model {
-            Model::Ising => {
-                self.run_with_spin::<IsingSpin, _, _>(rng, MetropolisFlipIntegrator::new())
-            }
-            Model::Heisenberg => {
-                self.run_with_spin::<HeisenbergSpin, _, _>(rng, MetropolisIntegrator::new())
-            }
+        match (&self.model, &self.algorithm) {
+            (Model::Ising, Algorithm::Metropolis) => self.run_with_spin::<IsingSpin, _, _>(
+                rng,
+                MetropolisFlipIntegrator::new(),
+                self.exchange.unwrap_or(1.0),
+            ),
+            (Model::Ising, Algorithm::Wolff) => self.run_with_spin::<IsingSpin, _, _>(
+                rng,
+                WolffIntegrator::from_lattice(self.exchange.unwrap_or(1.0), &self.lattice()),
+                self.exchange.unwrap_or(1.0),
+            ),
+            (Model::Heisenberg, Algorithm::Metropolis) => self
+                .run_with_spin::<HeisenbergSpin, _, _>(
+                    rng,
+                    MetropolisIntegrator::new(),
+                    self.exchange.unwrap_or(1.0),
+                ),
+            (Model::Heisenberg, Algorithm::Wolff) => Err(VegasError::NotImplementedError),
         }
-    }
-}
-
-/// Input for a Wolff simulation.
-#[derive(Debug, Deserialize, Serialize)]
-pub struct WolffInput {
-    exchange: Option<f64>,
-    sample: Sample,
-    steps: Vec<Step>,
-    output: Option<Output>,
-}
-
-impl WolffInput {
-    pub fn builder() -> WolffInputBuilder {
-        WolffInputBuilder::new()
-    }
-}
-
-impl Default for WolffInput {
-    fn default() -> Self {
-        WolffInput {
-            exchange: None,
-            sample: Default::default(),
-            steps: vec![
-                Step::Relax(Relax::default()),
-                Step::CoolDown(CoolDown::default()),
-            ],
-            output: Some(Output::default()),
-        }
-    }
-}
-
-pub struct WolffInputBuilder {
-    exchange: Option<f64>,
-    sample: Option<Sample>,
-    steps: Option<Vec<Step>>,
-    output: Option<Output>,
-}
-
-impl WolffInputBuilder {
-    pub fn new() -> Self {
-        WolffInputBuilder {
-            exchange: None,
-            sample: None,
-            steps: None,
-            output: None,
-        }
-    }
-
-    pub fn exchange(mut self, exchange: f64) -> Self {
-        self.exchange = Some(exchange);
-        self
-    }
-
-    pub fn sample(mut self, sample: Sample) -> Self {
-        self.sample = Some(sample);
-        self
-    }
-
-    pub fn steps(mut self, steps: Vec<Step>) -> Self {
-        self.steps = Some(steps);
-        self
-    }
-
-    pub fn output(mut self, output: Output) -> Self {
-        self.output = Some(output);
-        self
-    }
-
-    pub fn build(self) -> WolffInput {
-        WolffInput {
-            exchange: self.exchange,
-            sample: self.sample.unwrap_or_default(),
-            steps: self.steps.unwrap_or_default(),
-            output: self.output,
-        }
-    }
-}
-
-impl Default for WolffInputBuilder {
-    fn default() -> Self {
-        WolffInputBuilder::new()
-    }
-}
-
-impl WolffInput {
-    fn lattice(&self) -> Lattice {
-        let unitcell = match &self.sample.unitcell {
-            UnitCell::Name(name) => match name {
-                UnitCellName::SC => Lattice::sc(1.0),
-                UnitCellName::BCC => Lattice::bcc(1.0),
-                UnitCellName::FCC => Lattice::fcc(1.0),
-            },
-            UnitCell::Path(_path) => todo!(),
-        };
-        let UnitCellSize { x, y, z } = self.sample.size;
-        let PeriodicBoundaryConditions {
-            x: pbc_x,
-            y: pbc_y,
-            z: pbc_z,
-        } = self.sample.pbc;
-        let mut lattice = unitcell.expand(x, y, z);
-        if !pbc_x {
-            lattice = lattice.drop_x();
-        }
-        if !pbc_y {
-            lattice = lattice.drop_y();
-        }
-        if !pbc_z {
-            lattice = lattice.drop_z();
-        }
-        lattice
-    }
-
-    fn instruments<H: Hamiltonian<IsingSpin> + 'static>(
-        &self,
-    ) -> VegasResult<Vec<Box<dyn Instrument<H, IsingSpin>>>> {
-        let mut instruments: Vec<Box<dyn Instrument<_, _>>> =
-            vec![Box::new(StatSensor::<_, IsingSpin>::new(
-                Box::new(stdout()),
-            ))];
-        if let Some(output) = &self.output
-            && let Some(raw_filename) = &output.raw
-        {
-            instruments.push(Box::new(RawStatSensor::<_, IsingSpin>::try_new(
-                raw_filename,
-            )?));
-        }
-        if let Some(output) = &self.output
-            && let Some(state_output) = &output.state
-        {
-            instruments.push(Box::new(StateSensor::<_, IsingSpin>::try_new(
-                &state_output.path,
-                state_output.frequency,
-            )?));
-        }
-        Ok(instruments)
-    }
-
-    pub fn run<R: Rng>(&self, rng: &mut R) -> VegasResult<()> {
-        let lattice = self.lattice();
-        let integrator = WolffIntegrator::from_lattice(self.exchange.unwrap_or(1.0), &lattice);
-        let hamiltonian = hamiltonian!(Exchange::from_lattice(&lattice));
-        let instruments = self.instruments()?;
-        let mut machine = Machine::new(
-            Thermostat::new(2.8, Field::zero()),
-            hamiltonian,
-            integrator,
-            instruments,
-            State::<IsingSpin>::rand_with_size(rng, lattice.sites().len()),
-        );
-        for program in self.steps.iter() {
-            match program {
-                Step::Relax(relax) => {
-                    relax.run(rng, &mut machine)?;
-                }
-                Step::CoolDown(curie) => {
-                    curie.run(rng, &mut machine)?;
-                }
-                Step::Hysteresis(hysteresis) => {
-                    hysteresis.run(rng, &mut machine)?;
-                }
-            }
-        }
-        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! };
 //!
 //! let lattice = Lattice::sc(1.0).expand_x(10).expand_y(10).drop_z();
-//! let hamiltonian = Exchange::from_lattice(&lattice);
+//! let hamiltonian = Exchange::from_lattice(1.0, &lattice);
 //! let program = CoolDown::default()
 //!     .set_max_temperature(5.0)
 //!     .set_steps(10)


### PR DESCRIPTION
It's a little bit unconfortable to have two differen input files for
different algorithms, as you need to remember to update the input file
as well as the command you run from.

These changes update the command you run from:

```bash
vegas run <model> <input>
```

To just:

```bash
vegas run <input>
```

Drops the differentiation between metropolis and wolff inputs merging
them into one.
