### PR TITLE
refactor!: rename some inputs for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ You can use the toml input file format to run simulations. An example of input
 file is given below:
 
 ```toml
-# Model definition can be Ising or Heisenberg
+# Model definition can be Ising or Heisenberg.
 model = "Ising"
+
+# Algorithm definition can be Metropolis or Wolff.
 algorithm = "Metropolis"
 
 # You can create unit cells of different lattice types.
@@ -88,7 +90,7 @@ steps = 20000
 
 # You can define outputs to be written during the simulation.
 [output]
-raw = "./output.parquet"
+observables = "./output.parquet"
 
 [output.state]
 path = "./state.parquet"

--- a/docs/metropolis.toml
+++ b/docs/metropolis.toml
@@ -28,7 +28,7 @@ relax = 1000
 steps = 20000
 
 [output]
-raw = "./output.parquet"
+observables = "./output.parquet"
 
 [output.state]
 path = "./state.parquet"

--- a/docs/wolff.toml
+++ b/docs/wolff.toml
@@ -28,7 +28,7 @@ relax = 1000
 steps = 20000
 
 [output]
-raw = "./output.parquet"
+observables = "./output.parquet"
 
 [output.state]
 path = "./state.parquet"

--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -9,7 +9,7 @@ use crate::{
     accumulator::Accumulator,
     energy::Hamiltonian,
     error::{InstrumentResult, IoResult},
-    io::{ObservableParquetIO, StateParquetIO},
+    output::{ObservableParquetOutput, StateParquetOutput},
     state::{Spin, State},
     thermostat::Thermostat,
 };
@@ -141,13 +141,13 @@ where
     }
 }
 
-/// An instrument that stores raw stats in a parquet file.
-pub struct RawStatSensor<H, S>
+/// An instrument that stores observables in a parquet file.
+pub struct ObservableSensor<H, S>
 where
     H: Hamiltonian<S>,
     S: Spin,
 {
-    io: ObservableParquetIO,
+    io: ObservableParquetOutput,
     stage: usize,
     thermostat: Option<Thermostat<S>>,
     hamiltonian: Option<H>,
@@ -157,14 +157,14 @@ where
     phantom: PhantomData<S>,
 }
 
-impl<H, S> RawStatSensor<H, S>
+impl<H, S> ObservableSensor<H, S>
 where
     H: Hamiltonian<S>,
     S: Spin,
 {
     pub fn try_new<P: AsRef<Path>>(path: P) -> IoResult<Self> {
         Ok(Self {
-            io: ObservableParquetIO::try_new(path)?,
+            io: ObservableParquetOutput::try_new(path)?,
             stage: 0,
             thermostat: None,
             hamiltonian: None,
@@ -176,7 +176,7 @@ where
     }
 }
 
-impl<H, S> Instrument<H, S> for RawStatSensor<H, S>
+impl<H, S> Instrument<H, S> for ObservableSensor<H, S>
 where
     H: Hamiltonian<S>,
     S: Spin,
@@ -267,7 +267,7 @@ where
     H: Hamiltonian<S>,
     S: Spin,
 {
-    io: StateParquetIO,
+    io: StateParquetOutput,
     frequency: usize,
     relax: Option<bool>,
     step: usize,
@@ -283,7 +283,7 @@ where
 {
     pub fn try_new<P: AsRef<Path>>(path: P, frequency: usize) -> IoResult<Self> {
         Ok(Self {
-            io: StateParquetIO::try_new(path)?,
+            io: StateParquetOutput::try_new(path)?,
             frequency,
             relax: None,
             stage: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! Among others this library provides the following instruments:
 //!
 //! * `StatSensor` - An instrument that measures the statistical properties of the spin system.
-//! * `RawStatSensor` - An instrument that measures the raw statistical properties of the spin system.
+//! * `ObservableSensor` - An instrument that measures the observables of the spin system.
 //! * `StateSensor` - An instrument that writes the state of the spin system.
 //!
 //! ## Machine
@@ -132,8 +132,8 @@ pub mod error;
 pub mod input;
 pub mod instrument;
 pub mod integrator;
-pub mod io;
 pub mod machine;
+pub mod output;
 pub mod program;
 pub mod state;
 pub mod thermostat;

--- a/src/output.rs
+++ b/src/output.rs
@@ -23,14 +23,14 @@ use std::{
     sync::Arc,
 };
 
-pub struct ObservableParquetIO {
+pub struct ObservableParquetOutput {
     path: PathBuf,
     temp_path: PathBuf,
     schema: Arc<Schema>,
     writer: Option<ArrowWriter<File>>,
 }
 
-impl ObservableParquetIO {
+impl ObservableParquetOutput {
     pub fn try_new<P: AsRef<Path>>(path: P) -> IoResult<Self> {
         let temp_path = path.as_ref().with_extension("parquet.tmp");
         let file = File::create(&temp_path)?;
@@ -98,7 +98,7 @@ impl ObservableParquetIO {
     }
 }
 
-impl Drop for ObservableParquetIO {
+impl Drop for ObservableParquetOutput {
     fn drop(&mut self) {
         if let Some(self_writer) = self.writer.take() {
             if let Err(err) = self_writer.close() {
@@ -112,14 +112,14 @@ impl Drop for ObservableParquetIO {
     }
 }
 
-pub struct StateParquetIO {
+pub struct StateParquetOutput {
     path: PathBuf,
     temp_path: PathBuf,
     schema: Arc<Schema>,
     writer: Option<ArrowWriter<File>>,
 }
 
-impl StateParquetIO {
+impl StateParquetOutput {
     pub fn try_new<P: AsRef<Path>>(path: P) -> IoResult<Self> {
         let temp_path = path.as_ref().with_extension("parquet.tmp");
         let file = File::create(&temp_path)?;
@@ -186,7 +186,7 @@ impl StateParquetIO {
     }
 }
 
-impl Drop for StateParquetIO {
+impl Drop for StateParquetOutput {
     fn drop(&mut self) {
         if let Some(writer) = self.writer.take() {
             if let Err(err) = writer.close() {


### PR DESCRIPTION
The `raw` output was not that clear, it's now renamed to `observables`.
Same thing with the `RawStatSensor` which is now called
`ObservableSensor`. Finaly the `io` module shared some domain with the
`input` module. Now, the `io` module is just called `output`.
