### PR TITLE
chore: update vegas-lattice dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 
 [dependencies]
 rand = { version = "0.9", features = ["small_rng"] }
-vegas-lattice = "0.11.1"
+vegas-lattice = "0.12"
 sprs = "0.11"
 clap = { version = "4.5", features = ["cargo", "derive"] }
 rand_pcg = "0.9"

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -10,7 +10,7 @@
 //! combine multiple energy components into a single one. The compound
 //! energy component computes the total energy by summing the energies
 //! of its constituent components. Furthermore, a convenient macro
-//! `hamiltonian!` is provided to easily build complex hamiltonians by
+//! `hamiltonian!` is provided to easily build complex Hamiltonians by
 //! combining multiple energy components.
 //!
 //! # Example
@@ -174,16 +174,16 @@ impl Exchange {
 
     /// Create a new exchange energy from a lattice.
     pub fn from_lattice(exchange: f64, lattice: &Lattice) -> Self {
-        let nsites = lattice.sites().len();
-        let mut mat = TriMat::<f64>::new((nsites, nsites));
-        for vertex in lattice.vertices() {
-            if vertex.source() <= vertex.target() {
-                mat.add_triplet(vertex.source(), vertex.target(), exchange);
-                mat.add_triplet(vertex.target(), vertex.source(), exchange);
+        let n_sites = lattice.sites().len();
+        let mut mat = TriMat::<f64>::new((n_sites, n_sites));
+        for edge in lattice.edges() {
+            if edge.source() <= edge.target() {
+                mat.add_triplet(edge.source(), edge.target(), exchange);
+                mat.add_triplet(edge.target(), edge.source(), exchange);
             }
         }
-        let csr = mat.to_csr();
-        Self::new(csr)
+        let matrix = mat.to_csr();
+        Self::new(matrix)
     }
 }
 

--- a/src/integrator.rs
+++ b/src/integrator.rs
@@ -160,9 +160,9 @@ impl WolffIntegrator {
     /// Create a new Wolff integrator from a lattice.
     pub fn from_lattice(exchange: f64, lattice: &Lattice) -> Self {
         let mut neighbor_list = vec![Vec::new(); lattice.sites().len()];
-        for vertex in lattice.vertices() {
-            neighbor_list[vertex.source()].push(vertex.target());
-            neighbor_list[vertex.target()].push(vertex.source());
+        for edge in lattice.edges() {
+            neighbor_list[edge.source()].push(edge.target());
+            neighbor_list[edge.target()].push(edge.source());
         }
         Self {
             exchange,


### PR DESCRIPTION
This changes update the vegas-lattice dependency. This library no longer
uses the concept of vertex, but it uses edges instead.
