### PR TITLE
refactor!: Rename ZeemanEnergy to Zeeman for consistency

### DIFF
--- a/src/energy.rs
+++ b/src/energy.rs
@@ -4,7 +4,7 @@
 //! site for a given state.
 //!
 //! The module provides several built-in energy components, such as
-//! `Gauge`, `UniaxialAnisotropy`, `ZeemanEnergy`, and `Exchange`.
+//! `Gauge`, `UniaxialAnisotropy`, `Zeeman`, and `Exchange`.
 //!
 //! It also provides a `Compound` energy component that allows you to
 //! combine multiple energy components into a single one. The compound
@@ -122,14 +122,14 @@ where
 
 /// Energy resulting from a magnetic field.
 #[derive(Clone, Debug, Default)]
-pub struct ZeemanEnergy<S>
+pub struct Zeeman<S>
 where
     S: Spin,
 {
     phantom: PhantomData<S>,
 }
 
-impl<S> ZeemanEnergy<S>
+impl<S> Zeeman<S>
 where
     S: Spin,
 {
@@ -140,7 +140,7 @@ where
     }
 }
 
-impl<S> Hamiltonian<S> for ZeemanEnergy<S>
+impl<S> Hamiltonian<S> for Zeeman<S>
 where
     S: Spin,
 {
@@ -292,7 +292,7 @@ macro_rules! hamiltonian {
 #[cfg(test)]
 mod tests {
     use crate::{
-        energy::{Compound, Gauge, Hamiltonian, UniaxialAnisotropy, ZeemanEnergy},
+        energy::{Compound, Gauge, Hamiltonian, UniaxialAnisotropy, Zeeman},
         state::{Field, HeisenbergSpin, Spin, State},
         thermostat::Thermostat,
     };
@@ -317,7 +317,7 @@ mod tests {
     fn test_zeeman_energy() {
         let ups = State::<HeisenbergSpin>::up_with_size(10);
         let downs = State::<HeisenbergSpin>::down_with_size(10);
-        let anisotropy = ZeemanEnergy::new();
+        let anisotropy = Zeeman::new();
         assert!(
             anisotropy.total_energy(
                 &Thermostat::new(0.0, Field::new(HeisenbergSpin::up(), 1.0)),
@@ -338,7 +338,7 @@ mod tests {
     fn test_zeeman_energy_multiplies_correctly() {
         let ups = State::<HeisenbergSpin>::up_with_size(10);
         let downs = State::<HeisenbergSpin>::down_with_size(10);
-        let anisotropy = ZeemanEnergy::new();
+        let anisotropy = Zeeman::new();
         assert!(
             anisotropy.total_energy(
                 &Thermostat::new(0.0, Field::new(HeisenbergSpin::up(), 2.0)),

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,7 +1,7 @@
 //! Input structures for various simulations.
 
 use crate::{
-    energy::{Exchange, Hamiltonian, ZeemanEnergy},
+    energy::{Exchange, Hamiltonian, Zeeman},
     error::{VegasError, VegasResult},
     instrument::{Instrument, ObservableSensor, StatSensor, StateSensor},
     integrator::{Integrator, MetropolisFlipIntegrator, MetropolisIntegrator, WolffIntegrator},
@@ -268,10 +268,7 @@ impl Input {
         exchange: f64,
     ) -> VegasResult<()> {
         let lattice = self.lattice();
-        let hamiltonian = hamiltonian!(
-            Exchange::from_lattice(exchange, &lattice),
-            ZeemanEnergy::new()
-        );
+        let hamiltonian = hamiltonian!(Exchange::from_lattice(exchange, &lattice), Zeeman::new());
         let instruments = self.instruments::<_, S>()?;
         let mut machine = Machine::new(
             Thermostat::new(2.8, Field::zero()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! * `Exchange` - A hamiltonian that calculates the exchange energy of a spin system.
 //! * `Gauge` - A hamiltonian that calculates the gauge energy of a spin system.
 //! * `UniaxialAnisotropy` - A hamiltonian that calculates the uniaxial anisotropy energy of a spin system.
-//! * `ZeemanEnergy` - A hamiltonian that calculates the Zeeman energy of a spin system.
+//! * `Zeeman` - A hamiltonian that calculates the Zeeman energy of a spin system.
 //! * `Compound` - A hamiltonian that combines multiple hamiltonians.
 //!
 //! ## Instruments

--- a/src/program.rs
+++ b/src/program.rs
@@ -17,7 +17,7 @@
 //! use rand::SeedableRng;
 //! use rand_pcg::Pcg64;
 //! use vegas::{
-//!    energy::{Hamiltonian, ZeemanEnergy},
+//!    energy::{Hamiltonian, Zeeman},
 //!    integrator::MetropolisIntegrator,
 //!    machine::Machine,
 //!    program::{CoolDown, Program},
@@ -26,7 +26,7 @@
 //! };
 //!
 //! // Define a Hamiltonian (e.g., Zeeman Energy).
-//! let hamiltonian = ZeemanEnergy::new();
+//! let hamiltonian = Zeeman::new();
 //! let program = CoolDown::default()
 //!    .set_relax(10)
 //!    .set_steps(10);


### PR DESCRIPTION
`ZeemanEnergy` is the only energy component with the Energy suffix, here
we're fixing that by just calling the component `Zeeman` instead.
